### PR TITLE
use php 7.1.12 instead of 7.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Shippable CI image for PHP on Ubuntu 14.04. The following PHP versions are avail
 
   1. PHP 5.6.32
   2. PHP 7.0.26
-  3. PHP 7.2.0
+  3. PHP 7.1.12
 
 Each PHP version is installed with php-build and managed with phpenv. Several 
 PHP extensions are also available out of the box. Unless otherwise noted, the 
@@ -23,7 +23,7 @@ available in the image:
       * redis
       * zmq
 
-  2. PHP 7.0.26 and PHP 7.2.0
+  2. PHP 7.0.26 and PHP 7.1.12
       * amqp
       * bzip
       * intl

--- a/test/_php.sh
+++ b/test/_php.sh
@@ -5,7 +5,7 @@ echo "phpenv versions"
 $HOME/.phpenv/bin/phpenv versions
 printf "\n\n"
 
-declare -a versions=( '5.6' '7.0' '7.2')
+declare -a versions=( '5.6' '7.0' '7.1')
 
 for version in "${versions[@]}"
   do

--- a/version/7_1.sh
+++ b/version/7_1.sh
@@ -1,29 +1,29 @@
 #!/bin/bash -e
 
-#Build PHP 7.2.0
-echo "============ Building PHP 7.2.0 =============="
-PHP_BUILD_CONFIGURE_OPTS="--with-bz2 --enable-intl" php-build -i development 7.2.0 $HOME/.phpenv/versions/7.2
+#Build PHP 7.1.12
+echo "============ Building PHP 7.1.12 =============="
+PHP_BUILD_CONFIGURE_OPTS="--with-bz2 --enable-intl" php-build -i development 7.1.12 $HOME/.phpenv/versions/7.1
 
-# Setting phpenv to 7.2.0
-echo "============ Setting phpenv to 7.2 ============"
+# Setting phpenv to 7.1.12
+echo "============ Setting phpenv to 7.1 ============"
 phpenv rehash
-phpenv global 7.2
+phpenv global 7.1
 
 # Install phpunit
 echo "============ Installing PHPUnit ============="
 wget -nv https://phar.phpunit.de/phpunit-5.7.phar
 chmod +x phpunit-5.7.phar
-mv phpunit-5.7.phar $HOME/.phpenv/versions/7.2/bin/phpunit
+mv phpunit-5.7.phar $HOME/.phpenv/versions/7.1/bin/phpunit
 
 # Install Composer
 echo "============ Installing Composer ============"
 curl -sS http://getcomposer.org/installer | php
 chmod +x composer.phar
-mv composer.phar $HOME/.phpenv/versions/7.2/bin/composer
+mv composer.phar $HOME/.phpenv/versions/7.1/bin/composer
 
 #install pickle
 cd /tmp/pickle
-$HOME/.phpenv/versions/7.2/bin/composer install
+$HOME/.phpenv/versions/7.1/bin/composer install
 
 # Install php extensions
 echo "=========== Installing PHP extensions =============="


### PR DESCRIPTION
https://github.com/dry-dock/u14phpall/issues/43

verified by building locally. one of the existing plugins is not compatible with 7.2.0

https://app.shippable.com/github/Shippable/jobs/php_x86_64_Ubuntu_16_04_prep/builds/5a61c2bac43ac408005f9bc0/console
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2512